### PR TITLE
Validate multiple files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.21.3
 require github.com/xeipuuv/gojsonschema v1.2.0
 
 require (
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/sgreben/flagvar v1.10.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sgreben/flagvar v1.10.1 h1:ukN3zqVj9T9U7CiKG6owmejxswJYMbAg9Mxkhi1B4tw=
+github.com/sgreben/flagvar v1.10.1/go.mod h1:AxDmbFDIxZ4dHj2zg8LxuJn5CSwSS28iY/Wy56e+nhI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/main.go
+++ b/main.go
@@ -1,75 +1,76 @@
 package main
 
 import (
-    "fmt"
-    "io/fs"
-    "os"
-    "strings"
-    "github.com/xeipuuv/gojsonschema"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
 )
 
 var validationErrors []string
 
 func main() {
-    dirs, _ := os.ReadDir("./")
+	dirs, _ := os.ReadDir("./")
 
-    for _, dir := range dirs {
-        validate(dir)
-    }
+	for _, dir := range dirs {
+		validate(dir)
+	}
 
-    outputResults()
+	outputResults()
 }
 
 func validate(dir fs.DirEntry) {
-    dirName := dir.Name()
-    if dir.IsDir() && stringContains(gatewayDirNames(), dirName) {
-        fmt.Println("Running schema validation against sample " + dirName + " identities")
-        schemaLoader := gojsonschema.NewReferenceLoader("file://" + dirName + "/schema.json")
+	dirName := dir.Name()
+	if dir.IsDir() && stringContains(gatewayDirNames(), dirName) {
+		fmt.Println("Running schema validation against sample " + dirName + " identities")
+		schemaLoader := gojsonschema.NewReferenceLoader("file://" + dirName + "/schema.json")
 
-        files, _ := os.ReadDir(dirName + "/identities")
-        for _, file := range files {
-            fileName := file.Name()
-            if !file.IsDir() {
-                documentLoader := gojsonschema.NewReferenceLoader("file://" + dirName + "/identities/" + fileName)
+		files, _ := os.ReadDir(dirName + "/identities")
+		for _, file := range files {
+			fileName := file.Name()
+			if !file.IsDir() {
+				documentLoader := gojsonschema.NewReferenceLoader("file://" + dirName + "/identities/" + fileName)
 
-                result, err := gojsonschema.Validate(schemaLoader, documentLoader)
-                if err != nil {
-                    panic(err.Error())
-                }
+				result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+				if err != nil {
+					panic(err.Error())
+				}
 
-                if !result.Valid() {
-                    for _, desc := range result.Errors() {
-                        e := "- " + dirName + "/" + fileName + ": " + desc.Description()
-                        validationErrors = append(validationErrors, e)
-                    }
-                }
-            }
-        }
-    }
+				if !result.Valid() {
+					for _, desc := range result.Errors() {
+						e := "- " + dirName + "/" + fileName + ": " + desc.Description()
+						validationErrors = append(validationErrors, e)
+					}
+				}
+			}
+		}
+	}
 }
 
 func stringContains(slice []string, ele string) bool {
-    for _, sliceEle := range slice {
-        if sliceEle == ele {
-            return true
-        }
-    }
+	for _, sliceEle := range slice {
+		if sliceEle == ele {
+			return true
+		}
+	}
 
-    return false
+	return false
 }
 
 func gatewayDirNames() []string {
-    return []string{"3scale", "turnpike"}
+	return []string{"3scale", "turnpike"}
 }
 
 func outputResults() {
-    fmt.Println()
+	fmt.Println()
 
-    if len(validationErrors) > 0 {
-        fmt.Printf("Error(s) found in validation:\n")
-        fmt.Println(strings.Join(validationErrors, "\n"))
-        os.Exit(1)
-    } else {
-        fmt.Printf("No errors found.\n")
-    }
+	if len(validationErrors) > 0 {
+		fmt.Printf("Error(s) found in validation:\n")
+		fmt.Println(strings.Join(validationErrors, "\n"))
+		os.Exit(1)
+	} else {
+		fmt.Printf("No errors found.\n")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,25 +1,33 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
+	"text/tabwriter"
 
+	"github.com/sgreben/flagvar"
 	"github.com/xeipuuv/gojsonschema"
 )
 
-var validationErrors []string
+var validationErrors map[string][]string
 
 var (
-	schemaFile string
+	schemaFile   string
+	outputFormat flagvar.Enum
 )
 
 func main() {
+	validationErrors = make(map[string][]string)
+	outputFormat.Choices = []string{"text", "json"}
+	outputFormat.Value = "text"
+
 	flag.StringVar(&schemaFile, "schema", "./schema.json", "load `FILE` as the schema when validating")
+	flag.Var(&outputFormat, "format", "output in `FORMAT` (json, text)")
 
 	flag.Parse()
 
@@ -46,13 +54,32 @@ func main() {
 			if err != nil {
 				log.Fatalf("cannot validate document: %v", err)
 			}
-			for _, e := range errors {
-				validationErrors = append(validationErrors, fmt.Sprintf("%v: %v", filepath.Base(file), e))
-			}
+			validationErrors[filepath.Base(file)] = make([]string, 0)
+			validationErrors[filepath.Base(file)] = append(validationErrors[filepath.Base(file)], errors...)
 		}
 	}
 
-	outputResults()
+	switch outputFormat.Value {
+	case "json":
+		data, err := json.Marshal(validationErrors)
+		if err != nil {
+			log.Fatalf("cannot marshal json: %v", err)
+		}
+		fmt.Println(string(data))
+	case "text":
+		writer := tabwriter.NewWriter(os.Stdout, 4, 4, 2, ' ', 0)
+		fmt.Fprint(writer, "FILE\tERROR\n")
+		for file, errors := range validationErrors {
+			for _, err := range errors {
+				fmt.Fprintf(writer, "%v\t%v\n", file, err)
+			}
+		}
+		if err := writer.Flush(); err != nil {
+			log.Fatalf("unable to flush tab writer: %v", err)
+		}
+	default:
+		log.Fatalf("unknown format type: %v", outputFormat.Value)
+	}
 }
 
 // validateDocument runs JSON schema validation using the given loader on the
@@ -71,16 +98,4 @@ func validateDocument(loader gojsonschema.JSONLoader, document string) (bool, []
 		return false, errors, nil
 	}
 	return true, nil, nil
-}
-
-func outputResults() {
-	fmt.Println()
-
-	if len(validationErrors) > 0 {
-		fmt.Printf("Error(s) found in validation:\n")
-		fmt.Println(strings.Join(validationErrors, "\n"))
-		os.Exit(1)
-	} else {
-		fmt.Printf("No errors found.\n")
-	}
 }


### PR DESCRIPTION
Refactor the file loading logic to assume less about the filesystem
format.  The schema file must be provided via the -schema flag. Any
additional arguments on the command line are assumed to be documents and
are loaded sequentially before being validated against the given schema.
The special file name "-" is also supported; if present, the document
content is loaded for stdin enabling output to be piped into this
command for validation.