### PR TITLE
Fix typo on pattern

### DIFF
--- a/3scale/schema.json
+++ b/3scale/schema.json
@@ -155,7 +155,7 @@
           "if": {
             "properties": {
               "auth_type": {
-                "pattern": "(^cert-auth$|^uhc-auth&)"
+                "pattern": "(^cert-auth$|^uhc-auth$)"
               }
             }
           },


### PR DESCRIPTION
This was using the character `&` and given the context I think it should be using `$` (asserts position is at the end of a line)