### PR TITLE
Update the identity schema for UCH auth

### DIFF
--- a/3scale/identities/uhc.json
+++ b/3scale/identities/uhc.json
@@ -4,6 +4,9 @@
     "org_id": "321",
     "type": "System",
     "auth_type": "uhc-auth",
+    "system": {
+      "cluster_id": "456"
+    },
     "internal": {
       "org_id": "321",
       "auth_time": 1

--- a/3scale/schema.json
+++ b/3scale/schema.json
@@ -163,7 +163,23 @@
             "properties": {
               "type": {
                 "const": "System"
-              },
+              }
+            },
+            "required": [
+              "system"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "auth_type": {
+                "const": "cert-auth"
+              }
+            }
+          },
+          "then": {
+            "properties": {
               "system": {
                 "type": "object",
                 "properties": {
@@ -179,10 +195,31 @@
                   "cn"
                 ]
               }
-            },
-            "required": [
-              "system"
-            ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "auth_type": {
+                "const": "uhc-auth"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "system": {
+                "type": "object",
+                "properties": {
+                  "cluster_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cluster_id"
+                ]
+              }
+            }
           }
         }
       ],


### PR DESCRIPTION
While `uhc-auth` identities are both `system` identities, the base UCH identity[1] has a different `system` object structure, which we then annotate in the gateway[2].

[1] https://github.com/RedHatInsights/uhc-auth-proxy/blob/82eb28c73464db4a130ceece51e1295c2555f779/requests/cluster/cluster.go#L20-L30
[2] https://github.com/RedHatInsights/insights-3scale/blob/master/build/docker-assets/src/insights/identity.lua#L451-L464